### PR TITLE
Fix isValid method

### DIFF
--- a/modules/rpcvalue.js
+++ b/modules/rpcvalue.js
@@ -161,5 +161,5 @@ RpcValue.prototype.toChainPack = function()
 
 RpcValue.prototype.isValid = function()
 {
-	return this.value && this.type;
+	return (this.value || this.value === '') && this.type;
 }

--- a/rpcvalue.js
+++ b/rpcvalue.js
@@ -156,5 +156,5 @@ RpcValue.prototype.toChainPack = function()
 
 RpcValue.prototype.isValid = function()
 {
-	return this.value && this.type;
+	return (this.value || this.value === '') && this.type;
 }


### PR DESCRIPTION
Empty string in javascript is considered false, thus the condition didn't allowed empty string for key