### PR TITLE
Revert simplification of z.map/.imap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libshv-js",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Typescript implementation of libshv",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,9 +1,9 @@
 import {z, type ZodType} from 'zod';
-import {shvMapType, UInt} from './rpcvalue';
+import {type IMap, isIMap, isShvMap, type RpcValue, type ShvMap, UInt} from './rpcvalue';
 
-export const map = <T extends Record<string, ZodType<any, any, any>>>(schema: T) => z.object(schema).and(z.object({[shvMapType]: z.literal('map')}));
-export const recmap = <T extends ZodType<any, any, any>>(schema: T) => z.record(z.string(), schema).and(z.object({[shvMapType]: z.literal('map')}));
-export const imap = <T extends Record<string, ZodType<any, any, any>>>(schema: T) => z.object(schema).and(z.object({[shvMapType]: z.literal('imap')}));
+export const map = <T extends Record<string, ZodType<any, any, any>>>(schema: T) => z.custom<ShvMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isShvMap(data) && z.object(schema).safeParse(data).success);
+export const recmap = <T extends ZodType<any, any, any>>(schema: T) => z.custom<ShvMap<Record<string, z.infer<T>>>>((data: RpcValue) => isShvMap(data) && z.record(z.string(), schema).safeParse(data).success);
+export const imap = <T extends Record<string, ZodType<any, any, any>>>(schema: T) => z.custom<IMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isIMap(data) && z.object(schema).safeParse(data).success);
 export const int = () => z.number();
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- Zod needs the default argument, otherwise it'll infer as UInt<unknown>
 export const uint = () => z.instanceof(UInt<number>);


### PR DESCRIPTION
Unfortunately, the new code stripped the shvMapType symbol field. Not sure why.