### PR TITLE
Rework rpcmessage

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -1,0 +1,22 @@
+# vim: sw=2
+name: Misc
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-version-bump:
+    name: Check version bump
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check if version bumped
+        uses: del-systems/check-if-version-bumped@v2.0.3
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libshv-js",
-  "version": "3.3.6",
+  "version": "3.4.0",
   "description": "Typescript implementation of libshv",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/chainpack.ts
+++ b/src/chainpack.ts
@@ -100,7 +100,7 @@ class ChainPackReader {
         }
 
         const implReturn = (x: RpcValueType) => {
-            const ret = meta !== undefined ? new RpcValueWithMetaData(x, meta) : x;
+            const ret = meta !== undefined ? new RpcValueWithMetaData(meta, x) : x;
             return ret;
         };
 

--- a/src/cpon.ts
+++ b/src/cpon.ts
@@ -71,7 +71,7 @@ class CponReader {
         }
 
         const implReturn = (x: RpcValueType) => {
-            const ret = meta !== undefined ? new RpcValueWithMetaData(x, meta) : x;
+            const ret = meta !== undefined ? new RpcValueWithMetaData(meta, x) : x;
             return ret;
         };
 

--- a/src/rpcvalue.ts
+++ b/src/rpcvalue.ts
@@ -97,6 +97,8 @@ const isShvMap = (x: unknown): x is ShvMap => typeof x === 'object' && (x as Shv
 
 const isIMap = (x: unknown): x is IMap => typeof x === 'object' && (x as IMap)[shvMapType] === 'imap';
 
+const isMetaMap = (x: unknown): x is IMap => typeof x === 'object' && (x as MetaMap)[shvMapType] === 'metamap';
+
 const makeMetaMap = <T extends Record<string | number, RpcValue> = Record<string | number, RpcValue>, U extends Record<number, RpcValue> = Omit<T, typeof shvMapType>>(x: U = {} as U): MetaMap<U> => ({
     ...x,
     [shvMapType]: 'metamap',
@@ -112,10 +114,10 @@ const makeMap = <T extends Record<string, RpcValue> = Record<string, RpcValue>, 
     [shvMapType]: 'map',
 });
 
-class RpcValueWithMetaData {
-    constructor(public value: RpcValueType, public meta: MetaMap) {}
+class RpcValueWithMetaData<MetaSchema extends MetaMap = MetaMap, ValueSchema extends RpcValueType = RpcValueType> {
+    constructor(public meta: MetaSchema, public value: ValueSchema) {}
 }
 
 export type RpcValue = RpcValueType | RpcValueWithMetaData;
 
-export {shvMapType, Decimal, Double, type IMap, type MetaMap, RpcValueWithMetaData, type ShvMap, UInt, withOffset, makeMap, makeIMap, makeMetaMap, isIMap, isShvMap};
+export {shvMapType, Decimal, Double, type IMap, type MetaMap, RpcValueWithMetaData, type ShvMap, UInt, withOffset, makeMap, makeIMap, makeMetaMap, isIMap, isMetaMap, isShvMap};

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,11 +1,35 @@
 import {z, type ZodType} from 'zod';
-import {type IMap, isIMap, isShvMap, type RpcValue, type ShvMap, UInt} from './rpcvalue';
+import {Decimal, Double, type IMap, isIMap, isMetaMap, isShvMap, type MetaMap, type RpcValue, type RpcValueType, RpcValueWithMetaData, type ShvMap, UInt} from './rpcvalue';
 
-export const map = <T extends Record<string, ZodType<any, any, any>>>(schema: T) => z.custom<ShvMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isShvMap(data) && z.object(schema).safeParse(data).success);
+export const map = <T extends Record<string, ZodType<any, any, any>>>(schema?: T) => z.custom<ShvMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isShvMap(data) && (schema === undefined || z.object(schema).safeParse(data).success));
 export const recmap = <T extends ZodType<any, any, any>>(schema: T) => z.custom<ShvMap<Record<string, z.infer<T>>>>((data: RpcValue) => isShvMap(data) && z.record(z.string(), schema).safeParse(data).success);
-export const imap = <T extends Record<string, ZodType<any, any, any>>>(schema: T) => z.custom<IMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isIMap(data) && z.object(schema).safeParse(data).success);
+export const imap = <T extends Record<string, ZodType<any, any, any>>>(schema?: T) => z.custom<IMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isIMap(data) && (schema === undefined || z.object(schema).safeParse(data).success));
+export const metamap = <T extends Record<string | number, ZodType<any, any, any>>>(schema?: T) => z.custom<MetaMap<{[K in keyof T]: z.infer<T[K]>}>>((data: RpcValue) => isMetaMap(data) && (schema === undefined || z.object(schema).safeParse(data).success));
 export const int = () => z.number();
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- Zod needs the default argument, otherwise it'll infer as UInt<unknown>
 export const uint = () => z.instanceof(UInt<number>);
+
+const withMetaInstanceParser = z.instanceof(RpcValueWithMetaData);
+export const rpcvalue = () => z.union([
+    z.undefined(),
+    z.boolean(),
+    z.number(),
+    uint(),
+    z.instanceof(Double),
+    z.instanceof(Decimal),
+    z.instanceof(ArrayBuffer),
+    z.string(),
+    z.date(),
+    z.array(z.any()),
+    map(),
+    imap(),
+    withMetaInstanceParser,
+]);
+
+export const withMeta = <MetaSchema extends MetaMap, ValueSchema extends RpcValueType>(metaParser: ZodType<MetaSchema, any, any>, valueParser: ZodType<ValueSchema, any, any>) =>
+    z.custom<RpcValueWithMetaData<z.infer<typeof metaParser>, z.infer<typeof valueParser>>>((data: any) => withMetaInstanceParser.and(z.object({
+        meta: metaParser,
+        value: valueParser,
+    })).safeParse(data).success);
 
 export * from 'zod';


### PR DESCRIPTION
The reason the enum keys are now constants instead is because they get better Typescript completion. This might get better if PR56220 (don't want to tag it to spam it) gets merged, but for now this does well enough.