### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,7 @@
 # vim: sw=2
 name: Test
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libshv-js",
-  "version": "7.0.14",
+  "version": "7.0.15",
   "description": "Typescript implementation of libshv",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Potential fix for [https://github.com/silicon-heaven/libshv-js/security/code-scanning/3](https://github.com/silicon-heaven/libshv-js/security/code-scanning/3)

To fix the problem, explicitly specify minimal `GITHUB_TOKEN` permissions for the workflow or job instead of relying on repository/organization defaults. Since this workflow only checks out code and runs tests, it appears to only need read access to repository contents.

The best fix without changing functional behavior is to add a `permissions:` block at the workflow root (so it applies to all jobs) directly under `name: Test`. We’ll set `contents: read`, which matches CodeQL’s minimal recommendation and is enough for `actions/checkout` and reading source during `npm install` / `npm run test:ci`. No other scopes (like `pull-requests: write`) are needed based on the given steps. Concretely, in `.github/workflows/test.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 2 (`name: Test`). No imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
