### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ name: Lint
 permissions:
   contents: read
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libshv-js",
-  "version": "7.0.16",
+  "version": "7.0.17",
   "description": "Typescript implementation of libshv",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Potential fix for [https://github.com/silicon-heaven/libshv-js/security/code-scanning/2](https://github.com/silicon-heaven/libshv-js/security/code-scanning/2)

In general, this issue is fixed by explicitly declaring a `permissions` block that grants only the scopes required by the workflow or by each job. For read-only CI jobs that just checkout code and run local commands, `permissions: contents: read` at the workflow level is usually sufficient and follows least-privilege principles.

For this specific workflow, the easiest and least intrusive fix is to add a top-level `permissions` block (applies to all jobs) just under the `name: Lint` line. Neither `type-check` nor `xo` needs to write to the repository or interact with issues, PRs, or deployments, so we can safely restrict `GITHUB_TOKEN` to `contents: read`. No other code, steps, or imports need to change; we only add the YAML block in `.github/workflows/lint.yml`.

Concretely:
- Edit `.github/workflows/lint.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between `name: Lint` (line 2) and `concurrency:` (line 4).
- Leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
