### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 # vim: sw=2
 name: Lint
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libshv-js",
-  "version": "7.0.15",
+  "version": "7.0.16",
   "description": "Typescript implementation of libshv",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Potential fix for [https://github.com/silicon-heaven/libshv-js/security/code-scanning/1](https://github.com/silicon-heaven/libshv-js/security/code-scanning/1)

In general, fix this by explicitly adding a `permissions` block that grants the minimum required scopes. For a lint/type-check workflow that only reads source code and does not interact with PRs beyond reading them, `contents: read` at the workflow level is typically sufficient.

The best fix without changing existing functionality is to add a root-level `permissions` block near the top of `.github/workflows/lint.yml`, applying to all jobs. This avoids having to duplicate the block per job and does not affect behavior, because the jobs only read repo contents. Concretely: in `.github/workflows/lint.yml`, after the `name: Lint` line (line 2), insert:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed; this is purely a GitHub Actions workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
